### PR TITLE
Added resources page to navbar

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -17,6 +17,7 @@ const Header = ({ siteTitle }) => (
     <Nav siteTitle={siteTitle}>
         <NavItem link='/about' body='ABOUT' />
         <NavItem link='/meetings' body='MEETINGS' />
+	<NavItem link='/resources' body='RESOURCES' />
         <NavItem link='/contact' body='CONTACT' />
     </Nav>
 );


### PR DESCRIPTION
Used every ounce of my ~~type~~javascript knowledge to add the one line of code required to link to the resources page in the website. 
I'm sure it wasn't already in the navbar because we wanted it _"hidden"_
If that's the case just reject this pull, I only spent **105** hours on it